### PR TITLE
Enable nullable fields

### DIFF
--- a/lib/schema.js
+++ b/lib/schema.js
@@ -53,7 +53,7 @@ schema_jsonSchema.__jsonSchemaIdCounter = 0;
 
 function __build(name, schema) {
   var paths = Object.keys(schema.paths);
-  var path, jss, sch;
+  var path, jss, sch, oSchema;
   var result = {};
   if (name) {
     result.title = name;
@@ -64,8 +64,16 @@ function __build(name, schema) {
 
   for (path of paths) {
     jss = ensurePath(result, path);
-    sch = schema.paths[path].jsonSchema(jss.prop);
+    sch = schema.paths[path].jsonSchema(jss.prop); 
+
+    // if the default is set to null,
+    // then we assume it is a nullable type
+    oSchema = schema.paths[path];
+    if (oSchema && oSchema.options && {}.hasOwnProperty.call(oSchema.options, 'default') && oSchema.options.default === null) {
+      sch.type = [sch.type, 'null'];
+    }
     jss.cont.properties[jss.prop] = sch;
+  
     if (sch.__required) {
       jss.cont.required = jss.cont.required || [];
       jss.cont.required.push(jss.prop);


### PR DESCRIPTION
When `default: null`, mongoose allows fields to be nullable. However, the JSON schema created still expects the field to be a string—which causes any `null` values to fail validation. This accounts for that scenario.

Happy to discuss more or shift approach.