### PR TITLE
`schemaOptions` is not always defined

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -1,6 +1,6 @@
-const config = require('./config');
-const [FIELDS_MAPPING] = require('./options/fieldOptionsMapping');
-const { readConstraint } = require('./helpers');
+const config = require('./config')
+const [FIELDS_MAPPING] = require('./options/fieldOptionsMapping')
+const { readConstraint } = require('./helpers')
 
 module.exports = {
   simpleType_jsonSchema,
@@ -9,7 +9,7 @@ module.exports = {
   array_jsonSchema,
   mixed_jsonSchema,
   map_jsonSchema,
-};
+}
 
 /**
  * simpleType_jsonSchema - returns jsonSchema for simple-type parameter
@@ -19,13 +19,13 @@ module.exports = {
  * @return {object}      the jsonSchema for parameter
  */
 function simpleType_jsonSchema() {
-  const result = {};
+  const result = {}
 
-  result.type = this.instance.toLowerCase();
+  result.type = this.instance.toLowerCase()
 
-  __processOptions(result, extendOptions(this));
+  __processOptions(result, extendOptions(this))
 
-  return checkNullable(result);
+  return checkNullable(result)
 }
 
 function map_jsonSchema(name) {
@@ -35,13 +35,13 @@ function map_jsonSchema(name) {
       this.options.of != null
         ? __describe(`itemOf_${name}`, this.options.of)
         : true,
-  };
+  }
 
-  __processOptions(result, extendOptions(this));
+  __processOptions(result, extendOptions(this))
 
-  delete result.additionalProperties.__required;
+  delete result.additionalProperties.__required
 
-  return checkNullable(result);
+  return checkNullable(result)
 }
 
 /**
@@ -53,12 +53,12 @@ function map_jsonSchema(name) {
  * @return {object}      the jsonSchema for parameter
  */
 function objectId_jsonSchema(name) {
-  const result = simpleType_jsonSchema.call(this, name);
+  const result = simpleType_jsonSchema.call(this, name)
 
-  result.type = 'string';
-  result.pattern = '^[0-9a-fA-F]{24}$';
+  result.type = 'string'
+  result.pattern = '^[0-9a-fA-F]{24}$'
 
-  return checkNullable(result);
+  return checkNullable(result)
 }
 
 /**
@@ -68,12 +68,12 @@ function objectId_jsonSchema(name) {
  * @return {type}      description
  */
 function date_jsonSchema(name) {
-  const result = simpleType_jsonSchema.call(this, name);
+  const result = simpleType_jsonSchema.call(this, name)
 
-  result.type = 'string';
-  result.format = 'date-time';
+  result.type = 'string'
+  result.format = 'date-time'
 
-  return checkNullable(result);
+  return checkNullable(result)
 }
 
 /**
@@ -86,27 +86,30 @@ function date_jsonSchema(name) {
  * @return {object}      json schema
  */
 function array_jsonSchema(name) {
-  const result = {};
+  const result = {}
 
-  const itemName = `itemOf_${name}`;
+  const itemName = `itemOf_${name}`
 
-  result.type = 'array';
-  if (this.options.required) result.__required = true;
+  result.type = 'array'
+  if (this.options.required) result.__required = true
 
   if (this.schema) {
-    result.items = this.schema.jsonSchema(itemName);
+    result.items = this.schema.jsonSchema(itemName)
   } else {
-    result.items = this.caster.jsonSchema(itemName);
+    result.items = this.caster.jsonSchema(itemName)
   }
 
-  if (result.items.__required || this.schemaOptions.required) {
-    result.minItems = 1;
+  if (
+    result.items.__required ||
+    (this.schemaOptions && this.schemaOptions.required)
+  ) {
+    result.minItems = 1
   }
 
-  __processOptions(result, extendOptions(this));
-  delete result.items.__required;
+  __processOptions(result, extendOptions(this))
+  delete result.items.__required
 
-  return checkNullable(result);
+  return checkNullable(result)
 }
 
 /**
@@ -118,137 +121,138 @@ function array_jsonSchema(name) {
  * @return {object}      json schema
  */
 function mixed_jsonSchema(name) {
-  const result = __describe(name, this.options.type);
-  __processOptions(result, extendOptions(this));
+  const result = __describe(name, this.options.type)
+  __processOptions(result, extendOptions(this))
 
-  return checkNullable(result);
+  return checkNullable(result)
 }
 
-const transformMatch = match => (
+const transformMatch = (match) =>
   match instanceof RegExp
     ? match.toString().split('/').slice(1, -1).join('/')
     : match.toString()
-);
 
 function __processOptions(t, type) {
-  t.__required = !!readConstraint(type.required);
-  if (type.enum && type.enum.slice) t.enum = type.enum.slice();
-  if (type.ref) t['x-ref'] = type.ref;
-  if (type.min != null) t.minimum = readConstraint(type.min);
-  if (type.max != null) t.maximum = readConstraint(type.max);
-  if (type.minLength != null) t.minLength = readConstraint(type.minLength);
-  if (type.maxLength != null) t.maxLength = readConstraint(type.maxLength);
-  if (type.minlength != null) t.minLength = readConstraint(type.minlength);
-  if (type.maxlength != null) t.maxLength = readConstraint(type.maxlength);
-  if (type.examples != null) t.examples = type.examples;
-  if (type.match != null) t.pattern = transformMatch(readConstraint(type.match));
-  if (type.default !== undefined) t.default = type.default;
+  t.__required = !!readConstraint(type.required)
+  if (type.enum && type.enum.slice) t.enum = type.enum.slice()
+  if (type.ref) t['x-ref'] = type.ref
+  if (type.min != null) t.minimum = readConstraint(type.min)
+  if (type.max != null) t.maximum = readConstraint(type.max)
+  if (type.minLength != null) t.minLength = readConstraint(type.minLength)
+  if (type.maxLength != null) t.maxLength = readConstraint(type.maxLength)
+  if (type.minlength != null) t.minLength = readConstraint(type.minlength)
+  if (type.maxlength != null) t.maxLength = readConstraint(type.maxlength)
+  if (type.examples != null) t.examples = type.examples
+  if (type.match != null) t.pattern = transformMatch(readConstraint(type.match))
+  if (type.default !== undefined) t.default = type.default
 
-  t.description = type.description || type.descr || type.ref && `Refers to ${type.ref}`;
-  if (!t.description) delete t.description;
+  t.description =
+    type.description || type.descr || (type.ref && `Refers to ${type.ref}`)
+  if (!t.description) delete t.description
 
-  if (!t.title && type.title) t.title = type.title;
+  if (!t.title && type.title) t.title = type.title
 
-  const customFieldsMapping = config.get(FIELDS_MAPPING);
+  const customFieldsMapping = config.get(FIELDS_MAPPING)
 
-  Object.assign(t, customFieldsMapping(type));
+  Object.assign(t, customFieldsMapping(type))
 
-  return t;
+  return t
 }
 
 function __describe(name, type) {
-  if (!type) return {};
+  if (!type) return {}
 
-  if (type.jsonSchema instanceof Function) return type.jsonSchema(name);
+  if (type.jsonSchema instanceof Function) return type.jsonSchema(name)
 
   if (type.__buildingSchema) {
-    type.__jsonSchemaId = type.__jsonSchemaId
-      || `#subschema_${++__describe.__jsonSchemaIdCounter}`;
-    return { $ref: type.__jsonSchemaId };
+    type.__jsonSchemaId =
+      type.__jsonSchemaId || `#subschema_${++__describe.__jsonSchemaIdCounter}`
+    return { $ref: type.__jsonSchemaId }
   }
 
   if (type instanceof Array) {
-    type.__buildingSchema = true;
+    type.__buildingSchema = true
     const t = {
       type: 'array',
-      items: __describe(name && (`itemOf_${name}`), type[0]),
-    };
-    delete type.__buildingSchema;
-    if (t.items.__required) {
-      t.minItems = 1;
+      items: __describe(name && `itemOf_${name}`, type[0]),
     }
-    delete t.items.__required;
-    return t;
+    delete type.__buildingSchema
+    if (t.items.__required) {
+      t.minItems = 1
+    }
+    delete t.items.__required
+    return t
   }
 
   if (type === Date) {
     return {
       type: 'string',
       format: 'date-time',
-    };
+    }
   }
 
   if (type instanceof Function) {
-    type = type.name.toLowerCase();
+    type = type.name.toLowerCase()
     if (type === 'objectid') {
       return {
         type: 'string',
         pattern: '^[0-9a-fA-F]{24}$',
-      };
-    } if (type === 'mixed') {
-      return { };
+      }
+    }
+    if (type === 'mixed') {
+      return {}
     }
     return {
       type,
-    };
+    }
   }
 
   if (type.type) {
-    type.__buildingSchema = true;
-    const ts = __describe(name, type.type);
-    delete type.__buildingSchema;
-    __processOptions(ts, type);
-    return checkNullable(ts);
+    type.__buildingSchema = true
+    const ts = __describe(name, type.type)
+    delete type.__buildingSchema
+    __processOptions(ts, type)
+    return checkNullable(ts)
   }
 
   if (type.constructor.name !== 'Object') {
     return {
       type: type.constructor.name.toLowerCase(),
-    };
+    }
   }
 
   const result = {
     type: 'object',
     properties: {},
     required: [],
-  };
+  }
 
-  result.title = name;
+  result.title = name
 
-  const props = Object.keys(type);
-  type.__buildingSchema = true;
-  props.forEach(p => {
-    result.properties[p] = __describe(p, type[p]);
+  const props = Object.keys(type)
+  type.__buildingSchema = true
+  props.forEach((p) => {
+    result.properties[p] = __describe(p, type[p])
     if (result.properties[p].__required) {
-      result.required.push(p);
+      result.required.push(p)
     }
-    delete result.properties[p].__required;
-  });
-  delete type.__buildingSchema;
-  if (result.required.length === 0) delete result.required;
-  return result;
+    delete result.properties[p].__required
+  })
+  delete type.__buildingSchema
+  if (result.required.length === 0) delete result.required
+  return result
 }
 
-__describe.__jsonSchemaIdCounter = 0;
+__describe.__jsonSchemaIdCounter = 0
 
 function checkNullable(typeDef) {
   if (typeDef.default === null) {
-    typeDef.type = [typeDef.type, 'null'];
+    typeDef.type = [typeDef.type, 'null']
   }
 
-  return typeDef;
+  return typeDef
 }
 
 function extendOptions(mongooseTypeDef) {
-  return { ...mongooseTypeDef.options, required: mongooseTypeDef.isRequired };
+  return { ...mongooseTypeDef.options, required: mongooseTypeDef.isRequired }
 }

--- a/lib/types.js
+++ b/lib/types.js
@@ -1,6 +1,6 @@
-const config = require('./config')
-const [FIELDS_MAPPING] = require('./options/fieldOptionsMapping')
-const { readConstraint } = require('./helpers')
+const config = require('./config');
+const [FIELDS_MAPPING] = require('./options/fieldOptionsMapping');
+const { readConstraint } = require('./helpers');
 
 module.exports = {
   simpleType_jsonSchema,
@@ -9,7 +9,7 @@ module.exports = {
   array_jsonSchema,
   mixed_jsonSchema,
   map_jsonSchema,
-}
+};
 
 /**
  * simpleType_jsonSchema - returns jsonSchema for simple-type parameter
@@ -19,13 +19,13 @@ module.exports = {
  * @return {object}      the jsonSchema for parameter
  */
 function simpleType_jsonSchema() {
-  const result = {}
+  const result = {};
 
-  result.type = this.instance.toLowerCase()
+  result.type = this.instance.toLowerCase();
 
-  __processOptions(result, extendOptions(this))
+  __processOptions(result, extendOptions(this));
 
-  return checkNullable(result)
+  return checkNullable(result);
 }
 
 function map_jsonSchema(name) {
@@ -35,13 +35,13 @@ function map_jsonSchema(name) {
       this.options.of != null
         ? __describe(`itemOf_${name}`, this.options.of)
         : true,
-  }
+  };
 
-  __processOptions(result, extendOptions(this))
+  __processOptions(result, extendOptions(this));
 
-  delete result.additionalProperties.__required
+  delete result.additionalProperties.__required;
 
-  return checkNullable(result)
+  return checkNullable(result);
 }
 
 /**
@@ -53,12 +53,12 @@ function map_jsonSchema(name) {
  * @return {object}      the jsonSchema for parameter
  */
 function objectId_jsonSchema(name) {
-  const result = simpleType_jsonSchema.call(this, name)
+  const result = simpleType_jsonSchema.call(this, name);
 
-  result.type = 'string'
-  result.pattern = '^[0-9a-fA-F]{24}$'
+  result.type = 'string';
+  result.pattern = '^[0-9a-fA-F]{24}$';
 
-  return checkNullable(result)
+  return checkNullable(result);
 }
 
 /**
@@ -68,12 +68,12 @@ function objectId_jsonSchema(name) {
  * @return {type}      description
  */
 function date_jsonSchema(name) {
-  const result = simpleType_jsonSchema.call(this, name)
+  const result = simpleType_jsonSchema.call(this, name);
 
-  result.type = 'string'
-  result.format = 'date-time'
+  result.type = 'string';
+  result.format = 'date-time';
 
-  return checkNullable(result)
+  return checkNullable(result);
 }
 
 /**
@@ -86,30 +86,30 @@ function date_jsonSchema(name) {
  * @return {object}      json schema
  */
 function array_jsonSchema(name) {
-  const result = {}
+  const result = {};
 
-  const itemName = `itemOf_${name}`
+  const itemName = `itemOf_${name}`;
 
-  result.type = 'array'
-  if (this.options.required) result.__required = true
+  result.type = 'array';
+  if (this.options.required) result.__required = true;
 
   if (this.schema) {
-    result.items = this.schema.jsonSchema(itemName)
+    result.items = this.schema.jsonSchema(itemName);
   } else {
-    result.items = this.caster.jsonSchema(itemName)
+    result.items = this.caster.jsonSchema(itemName);
   }
 
   if (
-    result.items.__required ||
-    (this.schemaOptions && this.schemaOptions.required)
+    result.items.__required
+    || (this.schemaOptions && this.schemaOptions.required)
   ) {
-    result.minItems = 1
+    result.minItems = 1;
   }
 
-  __processOptions(result, extendOptions(this))
-  delete result.items.__required
+  __processOptions(result, extendOptions(this));
+  delete result.items.__required;
 
-  return checkNullable(result)
+  return checkNullable(result);
 }
 
 /**
@@ -121,138 +121,135 @@ function array_jsonSchema(name) {
  * @return {object}      json schema
  */
 function mixed_jsonSchema(name) {
-  const result = __describe(name, this.options.type)
-  __processOptions(result, extendOptions(this))
+  const result = __describe(name, this.options.type);
+  __processOptions(result, extendOptions(this));
 
-  return checkNullable(result)
+  return checkNullable(result);
 }
 
-const transformMatch = (match) =>
-  match instanceof RegExp
-    ? match.toString().split('/').slice(1, -1).join('/')
-    : match.toString()
+const transformMatch = match => (match instanceof RegExp
+  ? match.toString().split('/').slice(1, -1).join('/')
+  : match.toString());
 
 function __processOptions(t, type) {
-  t.__required = !!readConstraint(type.required)
-  if (type.enum && type.enum.slice) t.enum = type.enum.slice()
-  if (type.ref) t['x-ref'] = type.ref
-  if (type.min != null) t.minimum = readConstraint(type.min)
-  if (type.max != null) t.maximum = readConstraint(type.max)
-  if (type.minLength != null) t.minLength = readConstraint(type.minLength)
-  if (type.maxLength != null) t.maxLength = readConstraint(type.maxLength)
-  if (type.minlength != null) t.minLength = readConstraint(type.minlength)
-  if (type.maxlength != null) t.maxLength = readConstraint(type.maxlength)
-  if (type.examples != null) t.examples = type.examples
-  if (type.match != null) t.pattern = transformMatch(readConstraint(type.match))
-  if (type.default !== undefined) t.default = type.default
+  t.__required = !!readConstraint(type.required);
+  if (type.enum && type.enum.slice) t.enum = type.enum.slice();
+  if (type.ref) t['x-ref'] = type.ref;
+  if (type.min != null) t.minimum = readConstraint(type.min);
+  if (type.max != null) t.maximum = readConstraint(type.max);
+  if (type.minLength != null) t.minLength = readConstraint(type.minLength);
+  if (type.maxLength != null) t.maxLength = readConstraint(type.maxLength);
+  if (type.minlength != null) t.minLength = readConstraint(type.minlength);
+  if (type.maxlength != null) t.maxLength = readConstraint(type.maxlength);
+  if (type.examples != null) t.examples = type.examples;
+  if (type.match != null) t.pattern = transformMatch(readConstraint(type.match));
+  if (type.default !== undefined) t.default = type.default;
 
-  t.description =
-    type.description || type.descr || (type.ref && `Refers to ${type.ref}`)
-  if (!t.description) delete t.description
+  t.description = type.description || type.descr || (type.ref && `Refers to ${type.ref}`);
+  if (!t.description) delete t.description;
 
-  if (!t.title && type.title) t.title = type.title
+  if (!t.title && type.title) t.title = type.title;
 
-  const customFieldsMapping = config.get(FIELDS_MAPPING)
+  const customFieldsMapping = config.get(FIELDS_MAPPING);
 
-  Object.assign(t, customFieldsMapping(type))
+  Object.assign(t, customFieldsMapping(type));
 
-  return t
+  return t;
 }
 
 function __describe(name, type) {
-  if (!type) return {}
+  if (!type) return {};
 
-  if (type.jsonSchema instanceof Function) return type.jsonSchema(name)
+  if (type.jsonSchema instanceof Function) return type.jsonSchema(name);
 
   if (type.__buildingSchema) {
-    type.__jsonSchemaId =
-      type.__jsonSchemaId || `#subschema_${++__describe.__jsonSchemaIdCounter}`
-    return { $ref: type.__jsonSchemaId }
+    type.__jsonSchemaId = type.__jsonSchemaId || `#subschema_${++__describe.__jsonSchemaIdCounter}`;
+    return { $ref: type.__jsonSchemaId };
   }
 
   if (type instanceof Array) {
-    type.__buildingSchema = true
+    type.__buildingSchema = true;
     const t = {
       type: 'array',
       items: __describe(name && `itemOf_${name}`, type[0]),
-    }
-    delete type.__buildingSchema
+    };
+    delete type.__buildingSchema;
     if (t.items.__required) {
-      t.minItems = 1
+      t.minItems = 1;
     }
-    delete t.items.__required
-    return t
+    delete t.items.__required;
+    return t;
   }
 
   if (type === Date) {
     return {
       type: 'string',
       format: 'date-time',
-    }
+    };
   }
 
   if (type instanceof Function) {
-    type = type.name.toLowerCase()
+    type = type.name.toLowerCase();
     if (type === 'objectid') {
       return {
         type: 'string',
         pattern: '^[0-9a-fA-F]{24}$',
-      }
+      };
     }
     if (type === 'mixed') {
-      return {}
+      return {};
     }
     return {
       type,
-    }
+    };
   }
 
   if (type.type) {
-    type.__buildingSchema = true
-    const ts = __describe(name, type.type)
-    delete type.__buildingSchema
-    __processOptions(ts, type)
-    return checkNullable(ts)
+    type.__buildingSchema = true;
+    const ts = __describe(name, type.type);
+    delete type.__buildingSchema;
+    __processOptions(ts, type);
+    return checkNullable(ts);
   }
 
   if (type.constructor.name !== 'Object') {
     return {
       type: type.constructor.name.toLowerCase(),
-    }
+    };
   }
 
   const result = {
     type: 'object',
     properties: {},
     required: [],
-  }
+  };
 
-  result.title = name
+  result.title = name;
 
-  const props = Object.keys(type)
-  type.__buildingSchema = true
-  props.forEach((p) => {
-    result.properties[p] = __describe(p, type[p])
+  const props = Object.keys(type);
+  type.__buildingSchema = true;
+  props.forEach(p => {
+    result.properties[p] = __describe(p, type[p]);
     if (result.properties[p].__required) {
-      result.required.push(p)
+      result.required.push(p);
     }
-    delete result.properties[p].__required
-  })
-  delete type.__buildingSchema
-  if (result.required.length === 0) delete result.required
-  return result
+    delete result.properties[p].__required;
+  });
+  delete type.__buildingSchema;
+  if (result.required.length === 0) delete result.required;
+  return result;
 }
 
-__describe.__jsonSchemaIdCounter = 0
+__describe.__jsonSchemaIdCounter = 0;
 
 function checkNullable(typeDef) {
   if (typeDef.default === null) {
-    typeDef.type = [typeDef.type, 'null']
+    typeDef.type = [typeDef.type, 'null'];
   }
 
-  return typeDef
+  return typeDef;
 }
 
 function extendOptions(mongooseTypeDef) {
-  return { ...mongooseTypeDef.options, required: mongooseTypeDef.isRequired }
+  return { ...mongooseTypeDef.options, required: mongooseTypeDef.isRequired };
 }

--- a/test/suites/types.test.js
+++ b/test/suites/types.test.js
@@ -1,0 +1,17 @@
+const mongoose = require('../../index')(require('mongoose'));
+
+const { Schema } = mongoose;
+const assert = require('assert');
+
+describe('types', () => {
+  it('array of array should not cause any issue', () => {
+    const bookSchema = new Schema({
+      name: [[String]],
+
+    }, { _id: false });
+
+    const jsonSchema = bookSchema.jsonSchema('book');
+
+    assert.deepEqual(jsonSchema, { properties: { name: { items: { items: { type: 'string' }, type: 'array' }, type: 'array' } }, title: 'book', type: 'object' });
+  });
+});


### PR DESCRIPTION
Adding a simple check for `this.schemaOptions`.

It looks like my IDE really wanted to fix some of the syntax. If you want me to fix that, feel free to give me your prettier config if you have one and your `.editorconfig` if you have one