### PR TITLE
Support enum with custom error message

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -132,7 +132,10 @@ const transformMatch = match => (
 
 function __processOptions(t, type) {
   t.__required = !!readConstraint(type.required);
-  if (type.enum && type.enum.slice) t.enum = type.enum.slice();
+  if (type.enum) {
+    if (type.enum.slice) t.enum = type.enum.slice();
+    else if (type.enum.values) t.enum = type.enum.values;
+  }
   if (type.ref) t['x-ref'] = type.ref;
   if (type.min != null) t.minimum = readConstraint(type.min);
   if (type.max != null) t.maximum = readConstraint(type.max);

--- a/test/suites/ajv-validation.test.js
+++ b/test/suites/ajv-validation.test.js
@@ -98,6 +98,42 @@ describe('Validation: schema.jsonSchema()', () => {
     assert.ok(!isValid({ s: '' }));
   });
 
+  it('should build schema and validate strings with enum and error message', () => {
+    const mSchema = new mongoose.Schema({
+      s: {
+        type: String,
+        enum: {
+          values: ['1', '2', '3'],
+          message: '{VALUE} is not supported',
+        },
+      },
+    });
+
+    const jsonSchema = mSchema.jsonSchema();
+
+    assert.deepEqual(jsonSchema, {
+      type: 'object',
+      properties: {
+        s: {
+          type: 'string',
+          enum: ['1', '2', '3'],
+        },
+        _id: { type: 'string', pattern: '^[0-9a-fA-F]{24}$' },
+      },
+    });
+
+    const ajv = new Ajv();
+    const isValid = data => ajv.validate(jsonSchema, data);
+
+    assert.ok(isValid({ s: '1' }));
+    assert.ok(isValid({ s: '2' }));
+    assert.ok(isValid({ s: '3' }));
+    assert.ok(!isValid({ s: '4' }));
+    assert.ok(!isValid({ s: '0' }));
+    assert.ok(!isValid({ s: 1 }));
+    assert.ok(!isValid({ s: '' }));
+  });
+
   it('should build schema and validate strings with regExp', () => {
     const mSchema = new mongoose.Schema({
       s: { type: String, match: /^(abc|bac|cab)$/ },


### PR DESCRIPTION
Support custom error object syntax for enum type

example:
> Object syntax: enum: { values: ['Coffee', 'Tea'], message: '{VALUE} is not supported' }

https://mongoosejs.com/docs/validation.html#custom-error-messages