### PR TITLE
support mongoose ^8.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "jsonschema": "^1.2.2"
   },
   "peerDependencies": {
-    "mongoose": "^5.0.0 || ^6.0.0 || ^7.0.0"
+    "mongoose": "^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0"
   },
   "dependencies": {
     "pluralize": "^8.0.0"


### PR DESCRIPTION
Hi, I'm successfully using this package in my `mongoose` ^8 projects and we have to use `--legacy-peer-deps` everytime, can we update this? :)