### PR TITLE
Do not mark field as 'required' if condition is a function

### DIFF
--- a/lib/types.js
+++ b/lib/types.js
@@ -256,5 +256,10 @@ function checkNullable(typeDef) {
 }
 
 function extendOptions(mongooseTypeDef) {
-  return { ...mongooseTypeDef.options, required: mongooseTypeDef.isRequired };
+  const _required = mongooseTypeDef.options.required;
+
+  return {
+    ...mongooseTypeDef.options,
+    required: _required === true || ((_required instanceof Array) && _required[0] === true),
+  };
 }

--- a/test/suites/required-issue.test.js
+++ b/test/suites/required-issue.test.js
@@ -11,12 +11,18 @@ describe('schema.jsonSchema', () => {
         required: true,
         unique: true,
       },
+      year: {
+        type: Number,
+        required: true,
+      },
       description: {
         type: String,
       },
       internalName: {
         type: String,
-        required: true,
+        required() {
+          return this.year > 2000;
+        },
         unique: true,
       },
       manage: {
@@ -43,6 +49,9 @@ describe('schema.jsonSchema', () => {
       properties: {
         name: {
           type: 'string',
+        },
+        year: {
+          type: 'number',
         },
         description: {
           type: 'string',
@@ -72,7 +81,7 @@ describe('schema.jsonSchema', () => {
       },
       required: [
         'name',
-        'internalName',
+        'year',
       ],
     });
   });

--- a/test/suites/required-issue.test.js
+++ b/test/suites/required-issue.test.js
@@ -11,18 +11,12 @@ describe('schema.jsonSchema', () => {
         required: true,
         unique: true,
       },
-      year: {
-        type: Number,
-        required: true,
-      },
       description: {
         type: String,
       },
       internalName: {
         type: String,
-        required() {
-          return this.year > 2000;
-        },
+        required: true,
         unique: true,
       },
       manage: {
@@ -49,9 +43,6 @@ describe('schema.jsonSchema', () => {
       properties: {
         name: {
           type: 'string',
-        },
-        year: {
-          type: 'number',
         },
         description: {
           type: 'string',
@@ -81,7 +72,7 @@ describe('schema.jsonSchema', () => {
       },
       required: [
         'name',
-        'year',
+        'internalName',
       ],
     });
   });

--- a/test/suites/required.test.js
+++ b/test/suites/required.test.js
@@ -1,0 +1,65 @@
+const mongoose = require('../../index')(require('mongoose'));
+
+const { Schema } = mongoose;
+const assert = require('assert');
+
+describe('Required fields: schema.jsonSchema', () => {
+  it('should correctly translate field requirement', () => {
+    const bookSchema = new Schema({
+      name: {
+        type: String,
+        required() {
+          return this.year > 2000;
+        },
+      },
+      year: {
+        type: Number,
+        required: true,
+      },
+      description: {
+        type: String,
+      },
+      internalName: {
+        type: String,
+        required: [true, 'Internal name is required'],
+      },
+      author: {
+        type: String,
+        required: [
+          function () {
+            return this.year > 2000;
+          },
+          'Internal name is required',
+        ],
+      },
+    }, { _id: false });
+
+    const jsonSchema = bookSchema.jsonSchema('book');
+
+    assert.deepEqual(jsonSchema, {
+      title: 'book',
+      type: 'object',
+      properties: {
+        name: {
+          type: 'string',
+        },
+        year: {
+          type: 'number',
+        },
+        description: {
+          type: 'string',
+        },
+        internalName: {
+          type: 'string',
+        },
+        author: {
+          type: 'string',
+        },
+      },
+      required: [
+        'year',
+        'internalName',
+      ],
+    });
+  });
+});


### PR DESCRIPTION
Resolves https://github.com/DScheglov/mongoose-schema-jsonschema/issues/42 

# Rationale
If a field requirement is defined by a function then some of the documents can not contain the field, meaning - MongoDB Schema must not mark this field as `required`

# Problem
Current code version was checking `mongooseTypeDef.isRequired` which is set to true if any kind of requirement (constant `true` or a function) is defined

# Solution
Check `mongooseTypeDef.options.required` contents and return `true` only if the requirement is a hard requirement and not a function